### PR TITLE
autho proxy server changes 

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -43,9 +43,9 @@ module.exports = {
 
   AUTH0_URL: process.env.AUTH0_URL || 'https://api.topcoder.com/v5/auth', // Auth0 credentials for M2M token
   AUTH0_AUDIENCE: process.env.AUTH0_AUDIENCE || 'https://www.topcoder-dev.com',
-  TOKEN_CACHE_TIME: process.env.TOKEN_CACHE_TIME,
   AUTH0_CLIENT_ID: process.env.AUTH0_CLIENT_ID,
   AUTH0_CLIENT_SECRET: process.env.AUTH0_CLIENT_SECRET,
+  AUTH0_PROXY_SERVER_URL: process.env.AUTH0_PROXY_SERVER_URL,
 
   VERSION: process.env.VERSION || 'v3'
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lodash": "^4.17.10",
     "no-kafka": "^3.4.3",
     "superagent": "^4.1.0",
-    "tc-core-library-js": "appirio-tech/tc-core-library-js.git#v2.4.1",
+    "tc-core-library-js": "appirio-tech/tc-core-library-js.git#v2.6",
     "topcoder-healthcheck-dropin": "^1.0.2",
     "winston": "^2.2.0"
   },

--- a/src/common/helper.js
+++ b/src/common/helper.js
@@ -6,7 +6,7 @@ const config = require('config')
 const request = require('superagent')
 const m2mAuth = require('tc-core-library-js').auth.m2m
 const logger = require('./logger')
-const m2m = m2mAuth(_.pick(config, ['AUTH0_URL', 'AUTH0_AUDIENCE', 'TOKEN_CACHE_TIME']))
+const m2m = m2mAuth(_.pick(config, ['AUTH0_URL', 'AUTH0_AUDIENCE', 'AUTH0_PROXY_SERVER_URL']))
 
 /* Function to get M2M token
  * @returns {Promise}


### PR DESCRIPTION
autho proxy server changes and also it'll resolve excess m2m calls that was due to wrong token-cache-time setting. In new version of core api v2.6, no need explicity value of token-cache-time. It is taken care inside this lib.